### PR TITLE
fix: wrong deploy entry point

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -38,7 +38,7 @@ jobs:
         uses: denoland/deployctl@v1
         with:
           project: "andromeda"
-          entrypoint: "main.ts"
+          entrypoint: "_fresh/server.js"
           root: "."
           
           


### PR DESCRIPTION
The entry point has changed between Fresh 1 and 2. For Fresh 2 it should point to the generated server entry and launching via `main.ts` is not supported anymore, see https://fresh.deno.dev/docs/examples/migration-guide#updating-tasks